### PR TITLE
Added new Way to export data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=8.2",
         "spryker/csv": "^3.0.0",
-        "spryker/data-export-extension": "^0.1.0",
+        "spryker/data-export-extension": "dev-new-data-export-process as 1.0.x-dev",
         "spryker/graceful-runner": "^1.0.0",
         "spryker/kernel": "^3.30.0",
         "spryker/log": "^3.0.0",
@@ -20,7 +20,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Spryker\\": "src/Spryker/"
+            "Spryker\\": "src/Spryker/",
+            "Generated\\": "src/Generated/"
         }
     },
     "autoload-dev": {
@@ -44,5 +45,11 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/vitaliiShveider/data-export-extension"
+        }
+    ]
 }

--- a/src/Spryker/Shared/DataExport/DataExportObject.php
+++ b/src/Spryker/Shared/DataExport/DataExportObject.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Shared\DataExport;
+
+use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
+
+class DataExportObject
+{
+    protected array $transfer;
+
+    /**
+     * @param \Spryker\Shared\Kernel\Transfer\AbstractTransfer|array $transfer
+     * @param string $fieldDelimiter
+     * @param string $arrayDelimiter
+     * @param string $keyRoot
+     */
+    public function __construct(
+        AbstractTransfer|array $transfer,
+        protected readonly string $fieldDelimiter = '.',
+        protected readonly string $arrayDelimiter = '*',
+        protected readonly string $keyRoot = '$'
+    ) {
+        $this->transfer = is_array($transfer) ? $transfer : $transfer->toArray(true, true);
+    }
+
+    /**
+     * @param string $key
+     * @param $default
+     *
+     * @return mixed
+     */
+    public function get(string $key, $default = null): mixed
+    {
+        $key = ltrim($key, $this->keyRoot . $this->fieldDelimiter);
+        $keys = explode($this->fieldDelimiter, $key);
+        $value = $this->transfer;
+
+        return $this->getByKeys($keys, $value, $default);
+    }
+
+    /**
+     * @param array $keys
+     * @param mixed $value
+     * @param $default
+     *
+     * @return mixed
+     */
+    protected function getByKeys(array $keys, mixed $value, $default = null): mixed
+    {
+        while (count($keys)) {
+            $key = array_shift($keys);
+
+            if (!is_array($value)) {
+                return $default;
+            }
+
+            if ($key === $this->arrayDelimiter) {
+                return array_map(fn ($item) => $this->getByKeys($keys, $item, $default), $value);
+            }
+
+            if ($key === $this->keyRoot) {
+                return $this->getByKeys($keys, $this->transfer, $default);
+            }
+
+            if (!array_key_exists($key, $value)) {
+                return $default;
+            }
+
+            $value = $value[$key];
+        }
+
+        return $value;
+    }
+}

--- a/src/Spryker/Shared/DataExport/Transfer/data_export.transfer.xml
+++ b/src/Spryker/Shared/DataExport/Transfer/data_export.transfer.xml
@@ -30,6 +30,7 @@
         <property name="filterCriteria" type="array" singular="filterCriterion" associative="true"/>
         <property name="connection" type="DataExportConnectionConfiguration"/>
         <property name="hooks" type="array" singular="hook" associative="true"/>
+        <property name="batchSize" type="int"/>
     </transfer>
 
     <transfer name="DataExportFormatConfiguration">
@@ -44,6 +45,7 @@
     <transfer name="DataExportBatch">
         <property name="data" type="array" singular="dataItem"/>
         <property name="offset" type="int"/>
+        <property name="limit" type="int"/>
         <property name="fields" type="string[]" singular="field"/>
     </transfer>
 

--- a/src/Spryker/Zed/DataExport/Business/DataEntityPluginProvider/DataExportPluginProvider.php
+++ b/src/Spryker/Zed/DataExport/Business/DataEntityPluginProvider/DataExportPluginProvider.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\DataExport\Business\DataEntityPluginProvider;
+
+use Spryker\Zed\DataExport\Business\Exception\DataExporterNotFoundException;
+use Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityExporterPluginInterface;
+use Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityGeneratorPluginInterface;
+use Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityPluginInterface;
+use Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityReaderPluginInterface;
+
+class DataExportPluginProvider implements DataExportPluginProviderInterface
+{
+    /**
+     * @var array<string, array<string, \Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityPluginInterface>>
+     */
+    protected array $plugins = [];
+
+    /**
+     * @param array<\Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityExporterPluginInterface> $dataEntityExporterPlugins
+     * @param array<\Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityGeneratorPluginInterface> $dataExportDataEntityGeneratorPlugins
+     * @param array<\Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityReaderPluginInterface> $dataExportDataEntityReaderPlugins
+     */
+    public function __construct(
+        array $dataEntityExporterPlugins,
+        array $dataExportDataEntityGeneratorPlugins,
+        array $dataExportDataEntityReaderPlugins
+    ) {
+        $this->extendPluginsWithDataEntityPlugin($dataEntityExporterPlugins, DataEntityExporterPluginInterface::class);
+        $this->extendPluginsWithDataEntityPlugin($dataExportDataEntityGeneratorPlugins, DataEntityGeneratorPluginInterface::class);
+        $this->extendPluginsWithDataEntityPlugin($dataExportDataEntityReaderPlugins, DataEntityReaderPluginInterface::class);
+    }
+
+    /**
+     * @param string $dataEntity
+     * @param string|null $pluginInterface
+     *
+     * @return bool
+     */
+    public function exists(string $dataEntity, ?string $pluginInterface = null): bool
+    {
+        return $pluginInterface !== null
+            ? isset($this->plugins[$dataEntity][$pluginInterface])
+            : isset($this->plugins[$dataEntity]);
+    }
+
+    /**
+     * @param string $dataEntity
+     *
+     * @throws \Spryker\Zed\DataExport\Business\Exception\DataExporterNotFoundException
+     *
+     * @return void
+     */
+    public function requireDataEntityPlugin(string $dataEntity): void
+    {
+        if (!$this->exists($dataEntity)) {
+            throw new DataExporterNotFoundException(sprintf('Data export plugin not found for %s data entity', $dataEntity));
+        }
+    }
+
+    /**
+     * @template PluginInterface
+     *
+     * @param string $dataEntity
+     * @param class-string<PluginInterface> $pluginInterface
+     *
+     * @return PluginInterface
+     */
+    public function get(string $dataEntity, string $pluginInterface)
+    {
+        return $this->plugins[$dataEntity][$pluginInterface];
+    }
+
+    /**
+     * @param string $dataEntity
+     *
+     * @return \Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityPluginInterface
+     */
+    public function getDataEntityPlugin(string $dataEntity): DataEntityPluginInterface
+    {
+        return reset($this->plugins[$dataEntity]);
+    }
+
+    /**
+     * @param array<\Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityPluginInterface> $plugins
+     * @param string $pluginInterface
+     *
+     * @return void
+     */
+    protected function extendPluginsWithDataEntityPlugin(array $plugins, string $pluginInterface): void
+    {
+        foreach ($plugins as $dataEntityPlugin) {
+            $this->plugins[$dataEntityPlugin->getDataEntity()] = [$pluginInterface => $dataEntityPlugin];
+        }
+    }
+}

--- a/src/Spryker/Zed/DataExport/Business/DataEntityPluginProvider/DataExportPluginProviderInterface.php
+++ b/src/Spryker/Zed/DataExport/Business/DataEntityPluginProvider/DataExportPluginProviderInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\DataExport\Business\DataEntityPluginProvider;
+
+use Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityPluginInterface;
+
+interface DataExportPluginProviderInterface
+{
+    /**
+     * @param string $dataEntity
+     * @param string|null $pluginInterface
+     *
+     * @return bool
+     */
+    public function exists(string $dataEntity, ?string $pluginInterface = null): bool;
+
+    /**
+     * @param string $dataEntity
+     *
+     * @throws \Spryker\Zed\DataExport\Business\Exception\DataExporterNotFoundException
+     *
+     * @return void
+     */
+    public function requireDataEntityPlugin(string $dataEntity): void;
+
+    /**
+     * @template PluginInterface
+     *
+     * @param string $dataEntity
+     * @param class-string<PluginInterface> $pluginInterface
+     *
+     * @return PluginInterface
+     */
+    public function get(string $dataEntity, string $pluginInterface);
+
+    /**
+     * @param string $dataEntity
+     *
+     * @return \Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityPluginInterface
+     */
+    public function getDataEntityPlugin(string $dataEntity): DataEntityPluginInterface;
+}

--- a/src/Spryker/Zed/DataExport/Business/DataExportBusinessFactory.php
+++ b/src/Spryker/Zed/DataExport/Business/DataExportBusinessFactory.php
@@ -8,7 +8,13 @@
 namespace Spryker\Zed\DataExport\Business;
 
 use Spryker\Service\DataExport\DataExportServiceInterface;
+use Spryker\Zed\DataExport\Business\DataEntityPluginProvider\DataExportPluginProvider;
+use Spryker\Zed\DataExport\Business\DataEntityPluginProvider\DataExportPluginProviderInterface;
 use Spryker\Zed\DataExport\Business\Exporter\DataExportExecutor;
+use Spryker\Zed\DataExport\Business\Exporter\DataExportGeneratorExporter;
+use Spryker\Zed\DataExport\Business\Exporter\DataExportGeneratorExporterInterface;
+use Spryker\Zed\DataExport\Business\Mapper\DataExportMapper;
+use Spryker\Zed\DataExport\Business\Mapper\DataExportMapperInterface;
 use Spryker\Zed\DataExport\DataExportDependencyProvider;
 use Spryker\Zed\DataExport\Dependency\Facade\DataExportToGracefulRunnerFacadeInterface;
 use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
@@ -24,11 +30,40 @@ class DataExportBusinessFactory extends AbstractBusinessFactory
     public function createDataExportHandler(): DataExportExecutor
     {
         return new DataExportExecutor(
-            $this->getDataEntityExporterPlugins(),
+            $this->createDataExportPluginProvider(),
             $this->getDataExportService(),
             $this->getConfig(),
             $this->getGracefulRunnerFacade(),
+            $this->createDataExportGeneratorExporter(),
         );
+    }
+
+    /**
+     * @return \Spryker\Zed\DataExport\Business\DataEntityPluginProvider\DataExportPluginProviderInterface
+     */
+    public function createDataExportPluginProvider(): DataExportPluginProviderInterface
+    {
+        return new DataExportPluginProvider(
+            $this->getDataEntityExporterPlugins(),
+            $this->getDataEntityGeneratorPlugins(),
+            $this->getDataEntityReaderPlugins(),
+        );
+    }
+
+    /**
+     * @return \Spryker\Zed\DataExport\Business\Exporter\DataExportGeneratorExporterInterface
+     */
+    public function createDataExportGeneratorExporter(): DataExportGeneratorExporterInterface
+    {
+        return new DataExportGeneratorExporter($this->getDataExportService(), $this->createDataExportMapper());
+    }
+
+    /**
+     * @return \Spryker\Zed\DataExport\Business\Mapper\DataExportMapperInterface
+     */
+    public function createDataExportMapper(): DataExportMapperInterface
+    {
+        return new DataExportMapper();
     }
 
     /**
@@ -53,5 +88,21 @@ class DataExportBusinessFactory extends AbstractBusinessFactory
     public function getGracefulRunnerFacade(): DataExportToGracefulRunnerFacadeInterface
     {
         return $this->getProvidedDependency(DataExportDependencyProvider::FACADE_GRACEFUL_RUNNER);
+    }
+
+    /**
+     * @return array<\Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityReaderPluginInterface>
+     */
+    public function getDataEntityReaderPlugins(): array
+    {
+        return $this->getProvidedDependency(DataExportDependencyProvider::DATA_ENTITY_READER_PLUGINS);
+    }
+
+    /**
+     * @return array<\Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityGeneratorPluginInterface>
+     */
+    public function getDataEntityGeneratorPlugins(): array
+    {
+        return $this->getProvidedDependency(DataExportDependencyProvider::DATA_ENTITY_GENERATOR_PLUGINS);
     }
 }

--- a/src/Spryker/Zed/DataExport/Business/Exporter/DataExportExecutor.php
+++ b/src/Spryker/Zed/DataExport/Business/Exporter/DataExportExecutor.php
@@ -169,7 +169,7 @@ class DataExportExecutor
         $this->dataExportPluginProvider->requireDataEntityPlugin($dataEntity);
         $this->expandConfigurationWithPlugins($dataExportConfigurationTransfer);
 
-        if ($this->dataExportPluginProvider->exists($dataEntity, DataEntityExporterPluginInterface::class::class)) {
+        if ($this->dataExportPluginProvider->exists($dataEntity, DataEntityExporterPluginInterface::class)) {
             return $this->dataExportPluginProvider
                 ->get($dataEntity, DataEntityExporterPluginInterface::class)
                 ->export($dataExportConfigurationTransfer);

--- a/src/Spryker/Zed/DataExport/Business/Exporter/DataExportExecutor.php
+++ b/src/Spryker/Zed/DataExport/Business/Exporter/DataExportExecutor.php
@@ -247,7 +247,7 @@ class DataExportExecutor
                 continue;
             }
 
-            $exploded = explode(':', $field, 1);
+            $exploded = explode(':', $field);
             $fields[$exploded[0]] = $field;
         }
 

--- a/src/Spryker/Zed/DataExport/Business/Exporter/DataExportGeneratorExporter.php
+++ b/src/Spryker/Zed/DataExport/Business/Exporter/DataExportGeneratorExporter.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\DataExport\Business\Exporter;
+
+use Generated\Shared\Transfer\DataExportBatchTransfer;
+use Generated\Shared\Transfer\DataExportConfigurationTransfer;
+use Generated\Shared\Transfer\DataExportReportTransfer;
+use Generated\Shared\Transfer\DataExportResultTransfer;
+use Generator;
+use Spryker\Service\DataExport\DataExportServiceInterface;
+use Spryker\Zed\DataExport\Business\Mapper\DataExportMapperInterface;
+
+class DataExportGeneratorExporter implements DataExportGeneratorExporterInterface
+{
+    /**
+     * @var \Spryker\Service\DataExport\DataExportServiceInterface
+     */
+    protected $dataExportService;
+
+    /**
+     * @var \Spryker\Zed\DataExport\Business\Mapper\DataExportMapperInterface
+     */
+    protected $dataExportMapper;
+
+    /**
+     * @param \Spryker\Service\DataExport\DataExportServiceInterface $dataExportService
+     * @param \Spryker\Zed\DataExport\Business\Mapper\DataExportMapperInterface $dataExportMapper
+     */
+    public function __construct(
+        DataExportServiceInterface $dataExportService,
+        DataExportMapperInterface $dataExportMapper
+    ) {
+        $this->dataExportService = $dataExportService;
+        $this->dataExportMapper = $dataExportMapper;
+    }
+
+    /**
+     * @param \Generator<\Generated\Shared\Transfer\DataExportBatchTransfer> $dataExportGenerator
+     * @param \Generated\Shared\Transfer\DataExportConfigurationTransfer $dataExportConfigurationTransfer
+     *
+     * @return \Generated\Shared\Transfer\DataExportReportTransfer
+     */
+    public function exportFromGenerator(
+        Generator $dataExportGenerator,
+        DataExportConfigurationTransfer $dataExportConfigurationTransfer
+    ): DataExportReportTransfer {
+        $dataExportConfigurationTransfer->requireFields();
+        $dataExportResultTransfer = (new DataExportResultTransfer())
+            ->setDataEntity($dataExportConfigurationTransfer->getDataEntity())
+            ->setIsSuccessful(false);
+
+        foreach ($dataExportGenerator as $dataExportBatchTransfer) {
+            assert($dataExportBatchTransfer instanceof DataExportBatchTransfer);
+            $dataExportBatchTransfer->requireOffset()->requireLimit();
+            $dataExportBatchTransfer->setData(
+                $this->dataExportMapper
+                    ->map($dataExportBatchTransfer->getData(), $dataExportConfigurationTransfer->getFields()),
+            );
+
+            $dataExportWriteResponseTransfer = $this->dataExportService->write($dataExportBatchTransfer, $dataExportConfigurationTransfer);
+            $dataExportResultTransfer->setExportCount($dataExportBatchTransfer->getOffset());
+
+            if (!$dataExportWriteResponseTransfer->getIsSuccessful()) {
+                $dataExportResultTransfer->fromArray($dataExportWriteResponseTransfer->toArray(), true);
+
+                return $this->buildDataExportReportTransfer(false, $dataExportResultTransfer);
+            }
+
+            $dataExportResultTransfer->setFileName($dataExportWriteResponseTransfer->getFileName());
+        }
+
+        return $this->buildDataExportReportTransfer(true, $dataExportResultTransfer);
+    }
+
+    /**
+     * @param bool $isSuccessful
+     * @param \Generated\Shared\Transfer\DataExportResultTransfer $dataExportResultTransfer
+     *
+     * @return \Generated\Shared\Transfer\DataExportReportTransfer
+     */
+    protected function buildDataExportReportTransfer(bool $isSuccessful, DataExportResultTransfer $dataExportResultTransfer): DataExportReportTransfer
+    {
+        return (new DataExportReportTransfer())
+            ->setIsSuccessful($isSuccessful)
+            ->addDataExportResult($dataExportResultTransfer);
+    }
+}

--- a/src/Spryker/Zed/DataExport/Business/Exporter/DataExportGeneratorExporterInterface.php
+++ b/src/Spryker/Zed/DataExport/Business/Exporter/DataExportGeneratorExporterInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\DataExport\Business\Exporter;
+
+use Generated\Shared\Transfer\DataExportConfigurationTransfer;
+use Generated\Shared\Transfer\DataExportReportTransfer;
+use Generator;
+
+interface DataExportGeneratorExporterInterface
+{
+    /**
+     * @param \Generator<\Generated\Shared\Transfer\DataExportBatchTransfer> $dataExportGenerator
+     * @param \Generated\Shared\Transfer\DataExportConfigurationTransfer $dataExportConfigurationTransfer
+     *
+     * @return \Generated\Shared\Transfer\DataExportReportTransfer
+     */
+    public function exportFromGenerator(
+        Generator $dataExportGenerator,
+        DataExportConfigurationTransfer $dataExportConfigurationTransfer
+    ): DataExportReportTransfer;
+}

--- a/src/Spryker/Zed/DataExport/Business/Mapper/DataExportMapper.php
+++ b/src/Spryker/Zed/DataExport/Business/Mapper/DataExportMapper.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\DataExport\Business\Mapper;
+
+use Spryker\Shared\DataExport\DataExportObject;
+
+class DataExportMapper implements DataExportMapperInterface
+{
+    /**
+     * @param array<array> $data
+     * @param array<string> $fieldMapping
+     *
+     * @return array
+     */
+    public function map(array $data, array $fieldMapping): array
+    {
+        return array_map(fn ($item) => $this->mapItem($this->mapItemToDataExportObject($item), $fieldMapping), $data);
+    }
+
+    /**
+     * @param array $item
+     *
+     * @return \Spryker\Shared\DataExport\DataExportObject
+     */
+    protected function mapItemToDataExportObject(array $item): DataExportObject
+    {
+        return new DataExportObject($item);
+    }
+
+    /**
+     * @param \Spryker\Shared\DataExport\DataExportObject $dataExportObject
+     * @param array $fields
+     *
+     * @return array
+     */
+    protected function mapItem(DataExportObject $dataExportObject, array $fields): array
+    {
+        $result = [];
+
+        foreach ($fields as $pathKey) {
+            $explodedKey = explode(':', $pathKey, 2);
+            $exportKey = $explodedKey[0];
+            $pathKey = $explodedKey[1] ?? $explodedKey[0];
+
+            if (str_contains($exportKey, '*')) {
+                $result = array_merge($result, $this->mapArray($exportKey, $pathKey, $dataExportObject));
+
+                continue;
+            }
+
+            $result[$exportKey] = $dataExportObject->get($pathKey);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $exportKey
+     * @param string $pathKey
+     * @param \Spryker\Shared\DataExport\DataExportObject $data
+     *
+     * @return array
+     */
+    public function mapArray(string $exportKey, string $pathKey, DataExportObject $data): array
+    {
+        $result = [];
+        $prefix = substr($exportKey, 0, strpos($exportKey, '*'));
+        $postfix = substr($exportKey, strpos($exportKey, '*') + 1);
+
+        $res = $data->get($pathKey);
+
+        if (!is_array($res)) {
+            $result[$prefix . '0' . $postfix] = $res;
+
+            return $result;
+        }
+
+        foreach ($res as $key => $item) {
+            $result[$prefix . $key . $postfix] = $item;
+        }
+
+        return $result;
+    }
+}

--- a/src/Spryker/Zed/DataExport/Business/Mapper/DataExportMapper.php
+++ b/src/Spryker/Zed/DataExport/Business/Mapper/DataExportMapper.php
@@ -43,7 +43,7 @@ class DataExportMapper implements DataExportMapperInterface
         $result = [];
 
         foreach ($fields as $pathKey) {
-            $explodedKey = explode(':', $pathKey, 2);
+            $explodedKey = explode(':', $pathKey);
             $exportKey = $explodedKey[0];
             $pathKey = $explodedKey[1] ?? $explodedKey[0];
 

--- a/src/Spryker/Zed/DataExport/Business/Mapper/DataExportMapperInterface.php
+++ b/src/Spryker/Zed/DataExport/Business/Mapper/DataExportMapperInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\DataExport\Business\Mapper;
+
+interface DataExportMapperInterface
+{
+    /**
+     * @param array $data
+     * @param array $fieldMapping
+     *
+     * @return array
+     */
+    public function map(array $data, array $fieldMapping): array;
+}

--- a/src/Spryker/Zed/DataExport/DataExportDependencyProvider.php
+++ b/src/Spryker/Zed/DataExport/DataExportDependencyProvider.php
@@ -33,6 +33,16 @@ class DataExportDependencyProvider extends AbstractBundleDependencyProvider
     public const DATA_ENTITY_EXPORTER_PLUGINS = 'DATA_ENTITY_EXPORTER_PLUGINS';
 
     /**
+     * @var string
+     */
+    public const DATA_ENTITY_GENERATOR_PLUGINS = 'DATA_ENTITY_GENERATOR_PLUGINS';
+
+    /**
+     * @var string
+     */
+    public const DATA_ENTITY_READER_PLUGINS = 'DATA_ENTITY_READER_PLUGINS';
+
+    /**
      * @param \Spryker\Zed\Kernel\Container $container
      *
      * @return \Spryker\Zed\Kernel\Container
@@ -42,6 +52,8 @@ class DataExportDependencyProvider extends AbstractBundleDependencyProvider
         $container = parent::provideBusinessLayerDependencies($container);
         $container = $this->addDataExportService($container);
         $container = $this->addDataEntityExporterPlugins($container);
+        $container = $this->addDataEntityReaderPlugins($container);
+        $container = $this->addDataEntityGeneratorPlugins($container);
         $container = $this->addGracefulRunnerFacade($container);
 
         return $container;
@@ -110,5 +122,49 @@ class DataExportDependencyProvider extends AbstractBundleDependencyProvider
         });
 
         return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addDataEntityReaderPlugins(Container $container): Container
+    {
+        $container->set(static::DATA_ENTITY_READER_PLUGINS, function (): array {
+            return $this->getDataEntityReaderPlugins();
+        });
+
+        return $container;
+    }
+
+    /**
+     * @return array<\Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityReaderPluginInterface>
+     */
+    protected function getDataEntityReaderPlugins(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addDataEntityGeneratorPlugins(Container $container): Container
+    {
+        $container->set(static::DATA_ENTITY_GENERATOR_PLUGINS, function (): array {
+            return $this->getDataEntityGeneratorPlugins();
+        });
+
+        return $container;
+    }
+
+    /**
+     * @return array<\Spryker\Zed\DataExportExtension\Dependency\Plugin\DataEntityGeneratorPluginInterface>
+     */
+    protected function getDataEntityGeneratorPlugins(): array
+    {
+        return [];
     }
 }


### PR DESCRIPTION
## PR Description
Add a meaningful description here that will let us know what you want to fix with this PR or what functionality you want to add.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/data-export/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md

## Documentation
### How has data export worked before?
We needed to implement Business in module layer for data export. 
We needed to implement Repository for data export.
We needed to add new plugin.

Business layer code was huge.
Expamle in spryker/sales-data-export module.

### Way proposed in this pull request.
For example let's create QuoteRequestDataExport

What do we need to implement it now:

Add yml config:
```yml
version: 1

defaults:
    filter_criteria:
        created_at:
            from: "3 week ago 00:00:00"
            to: 'now'
    # ... 
    connection:
        #  your connection params

actions:
    - data_entity: quote-request
      destination: '{store}_quote_request.{extension}'
      format:
        type: json
        object: 'quote_request'
     fields:
         field_name_in_export_file:$.fieldNameInYourTransfer
    # provide a fields config you want to export. Also can be provided in plugin.
    # yml config will be merged with plugin fields config if you have it in plugin
    # Yml config override plugin config.
    # Needed for cases when you implemented one plugin for entity and want to configure fields for different exports in yml
```

Add Plugin 
```php
class QuoteRequestDataEntityReaderPlugin extends AbstractPlugin implements DataEntityReaderPluginInterface, DataEntityFieldsConfigPluginInterface
{
    public function getDataEntity(): string
    {
        return 'quote-request';
    }

    public function getDataBatch(DataExportConfigurationTransfer $dataExportConfigurationTransfer): DataExportBatchTransfer
    {
        // Call repository, facade method that grabs data from database.
        $criteriaTransfer = (new SomeCriteriaTransfer())->fromArray($dataExportConfigurationTransfer->getFilterCriteria());

        return $this->getRepository()->getQuoteRequestData(
            $criteriaTransfer,
            $dataExportConfigurationTransfer->getOffsetOrFail(),
            $dataExportConfigurationTransfer->getBatchSizeOrFail(),
        );
    }

    public function getFieldsConfig(): array // from DataEntityFieldsConfigPluginInterface
    {
        return [
            'quote_number:quoteNumber',
            'version_reference:latestVersion.versionReference',
            'items.*.material_number:latestVersion.quote.items.*.sapMaterialNumber',
            'items.*.name:latestVersion.quote.items.*.name',
            'items.*.quantity:latestVersion.quote.items.*.quantity',
            'items.*.status:latestVersion.quote.items.*.&.status',
            'created_at:createdAt',
            'id' => 'idQuoteRequest', // also you can use key => value configuration
            'updatedAt', // equals to 'updatedAt:updatedAt' or 'updatedAt' => 'updatedAt'
        ];
    }
}
```

Then just implement fetching data in the repository and it's done.
```php
public function getQuoteRequestData(
        DataExportConfigurationTransfer $dataExportConfigurationTransfer,
        int $offset,
        int $limit,
    ): DataExportBatchTransfer {
        $query = $this->getFactory()->getSpyQuoteRequestQuery();

        $this->prepareQuery($query);
        $this->applyFilters($query, $dataExportConfigurationTransfer);
        $query->setOffset($offset)->setLimit($limit);

        $quoteRequestEntities = $query->find();
        $dataExportBatchTransfer = (new DataExportBatchTransfer())->setOffset($offset)->setLimit($limit);

        $data = [];

        foreach ($quoteRequestEntities as $quoteRequestEntity) {
            $data[] = $this->mapExportDataItem($quoteRequestEntity);
        }

        return $dataExportBatchTransfer->setData($data);
    }
```


Also there is a possible to return your own `\Generator<\Generated\Shared\Transfer\DataExportResultTransfer>` with DataEntityGeneratorPluginInterface 
